### PR TITLE
Fixed omitting UTF-8 characters

### DIFF
--- a/woocommerce-yotpo/classes/class-wc-yotpo-export-reviews.php
+++ b/woocommerce-yotpo/classes/class-wc-yotpo-export-reviews.php
@@ -141,7 +141,7 @@ class Yotpo_Review_Export
     }
     
     private function getFirstWords($content = '', $number_of_words = 5) {
-    	$words = str_word_count($content,1);
+    	$words = explode(' ',$content);
     	if(count($words) > $number_of_words) {
     		return join(" ",array_slice($words, 0, $number_of_words));
     	}


### PR DESCRIPTION
Fixed omitting UTF-8 characters due to str_word_count limitation.
Using explode instead.